### PR TITLE
Optimized "Mode" does not always work

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -34,7 +34,7 @@ type templateData struct {
 
 func (g Generator) GenerateCborTypes() error {
 	fpath := filepath.Join(g.Path, g.Filename)
-	pkgs, err := packages.Load(&packages.Config{Mode: packages.NeedName}, "file="+fpath)
+	pkgs, err := packages.Load(&packages.Config{}, "file="+fpath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is likely a bug in golang.org/x/tools/go/packages, but whenever a specific Mode is specified, some of my files can not be found 😿 

Since this is merely an optimization, remove it entirely.